### PR TITLE
CON-6120: bump default uptycs-cli version to 3.5.2

### DIFF
--- a/src/commands/install_uptycs_cli.yml
+++ b/src/commands/install_uptycs_cli.yml
@@ -3,7 +3,7 @@ description: Install the Uptycs CLI (requires curl).
 parameters:
   version:
     type: string
-    default: 3.5.0
+    default: 3.5.2
     description: >
       Version of uptycs-cli to install, defaults to the latest stable release.
   install_dir:

--- a/src/jobs/image_scan.yml
+++ b/src/jobs/image_scan.yml
@@ -5,7 +5,7 @@ executor: docker
 parameters:
   version:
     type: string
-    default: 3.5.0
+    default: 3.5.2
     description: >
       Version of uptycs-cli to install, defaults to the latest stable release.
   install_dir:


### PR DESCRIPTION
This PR bumps the default version of uptycs-cli to the latest stable release - 3.5.2