### PR TITLE
CON-6246: bump uptycs-cli to 3.5.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    uptycs: uptycs/uptycs@0.1.3
+    uptycs: uptycs/uptycs@0.1.4
   workflows:
     build-and-scan:
       jobs:

--- a/src/commands/install_uptycs_cli.yml
+++ b/src/commands/install_uptycs_cli.yml
@@ -3,7 +3,7 @@ description: Install the Uptycs CLI (requires curl).
 parameters:
   version:
     type: string
-    default: 3.5.3
+    default: 3.5.4
     description: >
       Version of uptycs-cli to install, defaults to the latest stable release.
   install_dir:

--- a/src/jobs/image_scan.yml
+++ b/src/jobs/image_scan.yml
@@ -5,7 +5,7 @@ executor: docker
 parameters:
   version:
     type: string
-    default: 3.5.3
+    default: 3.5.4
     description: >
       Version of uptycs-cli to install, defaults to the latest stable release.
   install_dir:


### PR DESCRIPTION
This PR bumps the version of uptycs-cli to 3.5.4